### PR TITLE
Avoid marking strings as Errors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@
 
 module.exports = isError;
 
+function isObject(what) {
+  return typeof what === 'object' && what !== null;
+}
+
 /**
  * Test whether `value` is error object.
  *
@@ -13,6 +17,10 @@ module.exports = isError;
  */
 
 function isError(value) {
+  if !isObject(value) {
+    return false;
+  }
+
   switch (Object.prototype.toString.call(value)) {
     case '[object Error]': return true;
     case '[object Exception]': return true;


### PR DESCRIPTION
because of course:

```
> Object.prototype.toString.call('[object Error]')
'[object String]'
```